### PR TITLE
Use a custom chat card instead of a temporary item

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           readme: https://github.com/${{github.repository}}/blob/main/README.md
 
       # Create a zip file with all files required by the module to add to the release
-      - run: zip -r ./module.zip module.json LICENSE img/ src/ templates/
+      - run: zip -r ./module.zip module.json LICENSE img/ src/ templates/ css/
 
       # Create a release for this specific version
       - name: Update Release with Files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           readme: https://github.com/${{github.repository}}/blob/main/README.md
 
       # Create a zip file with all files required by the module to add to the release
-      - run: zip -r ./module.zip module.json LICENSE img/ src/
+      - run: zip -r ./module.zip module.json LICENSE img/ src/ templates/
 
       # Create a release for this specific version
       - name: Update Release with Files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2
+
+- Use a custom chat card to add a Remove Concentration Effect button
+- Add advantage and bonus to concentration checks in the Special Traits section of the character sheet
+
 # 1.1
 
 - Fix for not triggering concentration checks since a CE flag was moved

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This module helps manage concentration when casting certain spells. It will automatically apply the Concentrating status effect when you cast a spell with concentration. It will then prompt you to make a Concentration Check when you take damage.
 
+It also adds a Concentration section to the Special Traits part of the character sheet so you can specify advantage or bonuses to the concentration check.
+
 ## Other Modules
 
 Notes about other modules.

--- a/css/concentrator.css
+++ b/css/concentrator.css
@@ -1,0 +1,10 @@
+/* copied from dnd5e but renamed "card-buttons" to "custom-card-buttons" */
+.dnd5e.chat-card .custom-card-buttons {
+  margin: 5px 0;
+}
+.dnd5e.chat-card .custom-card-buttons button {
+  font-size: 12px;
+  height: 24px;
+  line-height: 20px;
+  margin: 2px 0;
+}

--- a/module.json
+++ b/module.json
@@ -32,6 +32,9 @@
   "esmodules": [
     "src/concentrator.js"
   ],
+  "styles": [
+    "css/concentrator.css"
+  ],
   "url": "replaced by workflow",
   "manifest": "replaced by workflow",
   "download": "replaced by workflow",

--- a/src/concentrator.js
+++ b/src/concentrator.js
@@ -202,7 +202,7 @@ async function onButtonClick(event) {
 
   // Handle different actions
   switch (button.dataset.action) {
-    case "save":
+    case "concentration":
       const speaker = ChatMessage.getSpeaker({ scene: canvas.scene, token: actor.token });
       // TODO: use Midi flags for adv/dis and bonuses
       await actor.rollAbilitySave(button.dataset.ability, { event, speaker });

--- a/src/concentrator.js
+++ b/src/concentrator.js
@@ -198,6 +198,10 @@ async function concentrationCheck(damage, actor, sourceName, effectId) {
   return ChatMessage.create(chatData);
 }
 
+/**
+ * The click handler for the concentration card buttons.
+ * @param {Event} event the event
+ */
 async function onButtonClick(event) {
   event.preventDefault();
   debug("onButtonClick called");

--- a/templates/chat-card.hbs
+++ b/templates/chat-card.hbs
@@ -10,7 +10,7 @@
     </div>
 
     <div class="custom-card-buttons">
-        <button data-action="save" data-ability="{{ability}}">
+        <button data-action="concentration" data-ability="{{ability}}">
             {{ localize "DND5E.SavingThrow" }} {{ localize "DND5E.SaveDC" dc=saveDC ability=abilityLabel }}
         </button>
 

--- a/templates/chat-card.hbs
+++ b/templates/chat-card.hbs
@@ -13,6 +13,8 @@
         <button data-action="save" data-ability="{{ability}}">
             {{ localize "DND5E.SavingThrow" }} {{ localize "DND5E.SaveDC" dc=saveDC ability=abilityLabel }}
         </button>
+
+        <button data-action="removeEffect" data-effect-id="{{effectId}}">Remove Concentration Effect</button>
     </div>
 
     {{!-- TODO: add button to remove active effect --}}

--- a/templates/chat-card.hbs
+++ b/templates/chat-card.hbs
@@ -17,8 +17,6 @@
         <button data-action="removeEffect" data-effect-id="{{effectId}}">Remove Concentration Effect</button>
     </div>
 
-    {{!-- TODO: add button to remove active effect --}}
-
     {{!-- TODO: add details about concentration, like the source and remaining duration? --}}
     {{!-- <footer class="card-footer">
         {{#each data.properties}}

--- a/templates/chat-card.hbs
+++ b/templates/chat-card.hbs
@@ -9,7 +9,7 @@
         {{{description}}}
     </div>
 
-    <div class="card-buttons">
+    <div class="custom-card-buttons">
         <button data-action="save" data-ability="{{ability}}">
             {{ localize "DND5E.SavingThrow" }} {{ localize "DND5E.SaveDC" dc=saveDC ability=abilityLabel }}
         </button>

--- a/templates/chat-card.hbs
+++ b/templates/chat-card.hbs
@@ -1,0 +1,26 @@
+<div class="dnd5e chat-card item-card" data-actor-id="{{actorId}}"
+     {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
+    <header class="card-header flexrow">
+        <img src="modules/concentrator/img/concentrating.svg" title="Concentration Check" width="36" height="36"/>
+        <h3 class="item-name">Concentration Check</h3>
+    </header>
+
+    <div class="card-content">
+        {{{description}}}
+    </div>
+
+    <div class="card-buttons">
+        <button data-action="save" data-ability="{{ability}}">
+            {{ localize "DND5E.SavingThrow" }} {{ localize "DND5E.SaveDC" dc=saveDC ability=abilityLabel }}
+        </button>
+    </div>
+
+    {{!-- TODO: add button to remove active effect --}}
+
+    {{!-- TODO: add details about concentration, like the source and remaining duration? --}}
+    {{!-- <footer class="card-footer">
+        {{#each data.properties}}
+        <span>{{this}}</span>
+        {{/each}}
+    </footer> --}}
+</div>


### PR DESCRIPTION
- the Saving Throw button is still a CON save under the hood, but we're handling it so we can apply special advantage/bonus to concentration checks
- add advantage and bonus as options in the Special Traits section of the character sheet
- add a button to remove the Concentration effect